### PR TITLE
Quick fix of download popup

### DIFF
--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -147,7 +147,8 @@ class Ui(QtWidgets.QMainWindow):
             ytube.streams.first().download(location)
 
         self.showPopUp(
-            f"{ytube.title} - has been downloaded successfully to {os.path.abspath(location)}")
+            f"{ytube.title} - has been downloaded successfully to:\
+            \n{os.path.abspath(location)}")
 
 
 app = QtWidgets.QApplication(sys.argv)

--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -147,8 +147,7 @@ class Ui(QtWidgets.QMainWindow):
             ytube.streams.first().download(location)
 
         self.showPopUp(
-            f"{ytube.title} - has been downloaded successfully to \
-            {os.path.abspath(location)}")
+            f"{ytube.title} - has been downloaded successfully to {os.path.abspath(location)}")
 
 
 app = QtWidgets.QApplication(sys.argv)


### PR DESCRIPTION
Removes a new line in the string which caused a gap in the text of the popup

Fixes: https://github.com/python-20/video-downloader/issues/25#issuecomment-582163908