### PR TITLE
Core mod - Inclusion of an interface class

### DIFF
--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -74,7 +74,8 @@ class YouTubeVideo(Video):
             progress_callback: The name of the callback function to be called
         """
         super().__init__(url, progress_callback)
-        self.yt = YouTube(self.url, on_progress_callback=self.progress_callback)
+        self.yt = YouTube(
+            self.url, on_progress_callback=self.progress_callback)
 
     @property
     def videoId(self):
@@ -115,7 +116,7 @@ class YouTubeVideo(Video):
         """
         return self.yt.streams.all()
 
-    def download(self, folder='./downloads', quality=None):
+    def download(self, location='./downloads', quality=None):
         """ Download the video. Default save location is './downloads'
 
         Override the same method in the Video class.
@@ -127,4 +128,4 @@ class YouTubeVideo(Video):
         """
         # TODO: support manual directory entry
         if quality is None:
-            self.yt.streams.first().download(folder)
+            self.yt.streams.first().download(location)

--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -26,9 +26,6 @@ class Video:
     def download(self, defaultQuality=None):
         pass
 
-    # def download_progress(self):
-    #     pass
-
 
 class YouTubeVideo(Video):
 
@@ -36,7 +33,6 @@ class YouTubeVideo(Video):
         self.url = url
         self.progress_callback = progress_callback
         self.yt = YouTube(self.url, on_progress_callback=self.progress_callback)
-        # self.filesize = self.yt.filesize
 
     @property
     def videoId(self):
@@ -71,9 +67,3 @@ class YouTubeVideo(Video):
         # TODO: support manual directory entry
         if quality is None:
             self.yt.streams.first().download(folder)
-
-    # def download_progress(self, stream, chunk, file_handle, bytes_remaining):
-    #     # print("on process callback")
-    #     file_size = stream.filesize
-    #     # print(f"{round((1 - bytes_remaining / file_size) * 100, 3)}%")
-    #     self.progress = round((1 - bytes_remaining / file_size) * 100, 3)

--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -26,15 +26,17 @@ class Video:
     def download(self, defaultQuality=None):
         pass
 
-    def download_progress(self):
-        pass
+    # def download_progress(self):
+    #     pass
 
 
 class YouTubeVideo(Video):
 
-    def __init__(self, url):
+    def __init__(self, url, progress_callback=None):
         self.url = url
-        self.yt = YouTube(self.url)
+        self.progress_callback = progress_callback
+        self.yt = YouTube(self.url, on_progress_callback=self.progress_callback)
+        # self.filesize = self.yt.filesize
 
     @property
     def videoId(self):
@@ -70,8 +72,8 @@ class YouTubeVideo(Video):
         if quality is None:
             self.yt.streams.first().download(folder)
 
-    def download_progress(self, stream, chunk, file_handle, bytes_remaining):
-        # print("on process callback")
-        file_size = stream.filesize
-        # print(f"{round((1 - bytes_remaining / file_size) * 100, 3)}%")
-        self.progress = round((1 - bytes_remaining / file_size) * 100, 3)
+    # def download_progress(self, stream, chunk, file_handle, bytes_remaining):
+    #     # print("on process callback")
+    #     file_size = stream.filesize
+    #     # print(f"{round((1 - bytes_remaining / file_size) * 100, 3)}%")
+    #     self.progress = round((1 - bytes_remaining / file_size) * 100, 3)

--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -1,21 +1,55 @@
+import pytube
+
 from pytube import YouTube
 
-# https://python-pytube.readthedocs.io/en/latest/user/quickstart.html
+# https://python-pytube3.readthedocs.io/en/latest/user/quickstart.html
 
 
-def getVideoThumbnail(video_id):
-    """ Get the video thumbnail
+class Video:
 
-    Returns:
-    URL of the thumbnail of the video
+    @property
+    def videoId(self):
+        pass
 
-    """
-    return f'https://img.youtube.com/vi/{video_id}/maxresdefault.jpg'
+    @property
+    def videoTitle(self):
+        pass
+
+    @property
+    def videoThumbnail(self):
+        pass
+
+    @property
+    def videoStreamQuality(self):
+        pass
+
+    def download(self, defaultQuality=None):
+        pass
+
+    def download_progress(self):
+        pass
 
 
-class YouTubeVideo:
+class YouTubeVideo(Video):
 
-    def getStreamQuality(self):
+    def __init__(self, url):
+        self.url = url
+        self.yt = YouTube(self.url)
+
+    @property
+    def videoId(self):
+        return pytube.extract.video_id(self.url)
+
+    @property
+    def videoTitle(self):
+        return self.yt.title
+
+    @property
+    def videoThumbnail(self):
+        return self.yt.thumbnail_url
+
+    @property
+    def videoStreamQuality(self):
         """ Get the available stream qualties of the video
 
         Returns:
@@ -24,7 +58,7 @@ class YouTubeVideo:
         """
         return self.yt.streams.all()
 
-    def download(self, location=None, quality=None):
+    def download(self, folder='./downloads', quality=None):
         """ Download the video. Default save location is './downloads'
 
         Args:
@@ -33,10 +67,8 @@ class YouTubeVideo:
 
         """
         # TODO: support manual directory entry
-        if location is None:
-            location = './downloads'
         if quality is None:
-            self.yt.streams.first().download(location)
+            self.yt.streams.first().download(folder)
 
     def download_progress(self, stream, chunk, file_handle, bytes_remaining):
         # print("on process callback")

--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -8,8 +8,8 @@ from pytube import YouTube
 class Video:
     """ Base class for the (Service)Video object.
 
-    This is an interface class, should not be used directly. A new video service
-    is registered by subclassing it.
+    This is an interface class, it should not be used directly. A new video
+    service is registered by subclassing it.
     """
 
     def __init__(self, url, progress_callback=None):
@@ -63,28 +63,51 @@ class Video:
 
 
 class YouTubeVideo(Video):
+    """ Container for the YouTube video data.
+    """
 
     def __init__(self, url, progress_callback=None):
+        """ Construct the YouTubeVideo object.
+
+        args:
+            url: The URL of a YouTube video
+            progress_callback: The name of the callback function to be called
+        """
         super().__init__(url, progress_callback)
         self.yt = YouTube(self.url, on_progress_callback=self.progress_callback)
 
     @property
     def videoId(self):
+        """ Return the ID of the video.
+
+        Override the correspondent method in the Video class.
+
+        """
         return pytube.extract.video_id(self.url)
 
     @property
     def videoTitle(self):
+        """ Return the title of the video.
+
+        Override the correspondent method in the Video class.
+
+        """
         return self.yt.title
 
     @property
     def videoThumbnail(self):
+        """ Return the video thumbnail.
+
+        Override the correspondent method in the Video class.
+
+        """
         return self.yt.thumbnail_url
 
     @property
     def videoStreamQuality(self):
         """ Get the available stream qualities of the video.
 
-        Override the same method in the Video class.
+        Override the correspondent method in the Video class.
 
         Returns:
         A list of stream object consisting of the available stream qualities for the video

--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -6,32 +6,66 @@ from pytube import YouTube
 
 
 class Video:
+    """ Base class for the (Service)Video object.
+
+    This is an interface class, should not be used directly. A new video service
+    is registered by subclassing it.
+    """
+
+    def __init__(self, url, progress_callback=None):
+        """ Initialize the Video object.
+
+        Args:
+            url: The URL of the video
+            progress_callback: The name of the callback function to be called
+        """
+        self.url = url
+        self.progress_callback = progress_callback
 
     @property
     def videoId(self):
-        pass
+        """ Return the ID of the video.
+
+        This method should be overriden in the (Service)Video class.
+        """
+        raise NotImplementedError
 
     @property
     def videoTitle(self):
-        pass
+        """ Return the title of the video.
+
+        This method should be overriden in the (Service)Video class.
+        """
+        raise NotImplementedError
 
     @property
     def videoThumbnail(self):
-        pass
+        """ Return the video thumbnail.
+
+        This method should be overriden in the (Service)Video class.
+        """
+        raise NotImplementedError
 
     @property
     def videoStreamQuality(self):
-        pass
+        """ Return the available stream qualities of the video.
+
+        This method should be overriden in the (Service)Video class.
+        """
+        raise NotImplementedError
 
     def download(self, defaultQuality=None):
-        pass
+        """ Download the video.
+
+        This method should be overriden in the (Service)Video class.
+        """
+        raise NotImplementedError
 
 
 class YouTubeVideo(Video):
 
     def __init__(self, url, progress_callback=None):
-        self.url = url
-        self.progress_callback = progress_callback
+        super().__init__(url, progress_callback)
         self.yt = YouTube(self.url, on_progress_callback=self.progress_callback)
 
     @property
@@ -48,16 +82,20 @@ class YouTubeVideo(Video):
 
     @property
     def videoStreamQuality(self):
-        """ Get the available stream qualties of the video
+        """ Get the available stream qualities of the video.
+
+        Override the same method in the Video class.
 
         Returns:
-        A list of stream object consist of the available stream qualities for the video
+        A list of stream object consisting of the available stream qualities for the video
 
         """
         return self.yt.streams.all()
 
     def download(self, folder='./downloads', quality=None):
         """ Download the video. Default save location is './downloads'
+
+        Override the same method in the Video class.
 
         Args:
             location: The location to save the video

--- a/youtubedl/gui.py
+++ b/youtubedl/gui.py
@@ -1,11 +1,10 @@
 import sys
-import time
 import os
 import urllib
 from PyQt5 import QtGui, QtWidgets, uic
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtCore import Qt
 from pytube import YouTube
 
 # from core import getVideoThumbnail
@@ -53,14 +52,16 @@ class Ui(QtWidgets.QMainWindow):
         """
 
         link = self.lineEditURL.text()
-        self.ytube = YouTubeVideo(link, progress_callback=self.download_progress)
+        self.ytube = YouTubeVideo(
+            link, progress_callback=self.download_progress)
 
         # Display video title
         self.labelVideoTitle.setText(self.ytube.videoTitle)
 
         # Display thumbnail image
         pixmap = QPixmap()
-        pixmap.loadFromData(urllib.request.urlopen(self.ytube.videoThumbnail).read())
+        pixmap.loadFromData(urllib.request.urlopen(
+            self.ytube.videoThumbnail).read())
         pixmap = pixmap.scaled(
             230, 230, Qt.KeepAspectRatio, Qt.FastTransformation)
         self.labelThumbnail.setPixmap(pixmap)
@@ -77,7 +78,8 @@ class Ui(QtWidgets.QMainWindow):
         self.user_directory = str(QFileDialog.getExistingDirectory(
             self, "Select Directory"))
         self.lineEditDownloadLocation.setText(self.user_directory)
-        self.logger.info(f"function: getSaveLocation - directory: {self.user_directory}")
+        self.logger.info(
+            f"function: getSaveLocation - directory: {self.user_directory}")
 
     def onSaveLocationChange(self):
         """ Get save location by user text input
@@ -128,11 +130,11 @@ class Ui(QtWidgets.QMainWindow):
         """
         # TODO: support manual directory entry
 
-        print(f"location: {location}")
-        print(f"quality: {quality}")
+        self.logger.info(f"location: {location}")
+        self.logger.info(f"quality: {quality}")
 
         if quality is None:
-            self.ytube.download(folder=location)
+            self.ytube.download(location=location)
 
         self.showPopUp(
             f"{self.ytube.videoTitle} - has been downloaded successfully to:\

--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -114,7 +114,6 @@ class Ui(QtWidgets.QMainWindow):
         """
         Updates progress bar on download_progress callback
         """
-        print("on process callback")
         file_size = stream.filesize
         self.progressBar.setValue(
             round((1 - bytes_remaining / file_size) * 100, 3))

--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -8,12 +8,13 @@ from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import Qt, QThread, pyqtSignal
 from pytube import YouTube
 
-from core import getVideoThumbnail
+# from core import getVideoThumbnail
+from core import YouTubeVideo
 from helpers import Helpers
 
 
-ytube = None
-directory = None
+# ytube = None
+DEFAULT_DIRECTORY = './downloads'
 
 
 class Ui(QtWidgets.QMainWindow):
@@ -42,73 +43,69 @@ class Ui(QtWidgets.QMainWindow):
         # test URL
         self.lineEditURL.setText("https://www.youtube.com/watch?v=9bZkp7q19f0")
 
+        # user directory (chosen for the download)
+        self.user_directory = DEFAULT_DIRECTORY
+
         self.show()
 
     def enterURL(self):
-        """ When OK button is pressed.         
-        Retreive information of the video using pytube using the URL entered and process it        
+        """ When OK button is pressed.
+        Use the given URL to retrieve video information and process it
 
         """
 
         link = self.lineEditURL.text()
-        global ytube
-        ytube = YouTube(link, on_progress_callback=self.download_progress)
+        self.ytube = YouTubeVideo(link) #, on_progress_callback=self.download_progress)
 
         # Display video title
-        self.labelVideoTitle.setText(ytube.title)
+        self.labelVideoTitle.setText(self.ytube.videoTitle)
 
         # Display thumbnail image
-        thumbnail_data = urllib.request.urlopen(
-            getVideoThumbnail(ytube.video_id)).read()
         pixmap = QPixmap()
-        pixmap.loadFromData(thumbnail_data)
+        pixmap.loadFromData(urllib.request.urlopen(self.ytube.videoThumbnail).read())
         pixmap = pixmap.scaled(
             230, 230, Qt.KeepAspectRatio, Qt.FastTransformation)
         self.labelThumbnail.setPixmap(pixmap)
 
         # debug information
-        self.logger.info(f"URL: {link}")
-        self.logger.info(f"Video Title: {ytube.title}")
+        self.logger.info(f"URL: {self.ytube.url}")
+        self.logger.info(f"Video Title: {self.ytube.videoTitle}")
         self.logger.info(
-            f"Video Thumbnail: {getVideoThumbnail(ytube.video_id)}")
+            f"Video Thumbnail: {self.ytube.videoThumbnail}")
 
     def getSaveLocation(self):
         """ Get user selected directory when the get location button is clicked.
         """
-        global directory
-        directory = str(QFileDialog.getExistingDirectory(
+        self.user_directory = str(QFileDialog.getExistingDirectory(
             self, "Select Directory"))
-        self.lineEditDownloadLocation.setText(directory)
-        self.logger.info(f"function: getSaveLocation - directory: {directory}")
+        self.lineEditDownloadLocation.setText(self.user_directory)
+        self.logger.info(f"function: getSaveLocation - directory: {self.user_directory}")
 
     def onSaveLocationChange(self):
         """ Get save location by user text input
         """
-        global directory
         entered_directory = self.lineEditDownloadLocation.text()
         # check if directory exist
         if not os.path.isdir(entered_directory):
             self.lineEditDownloadLocation.setText("")
             self.showPopUp("Directory is not valid. Please re select")
         else:
-            directory = entered_directory
+            self.user_directory = entered_directory
         self.logger.info(
-            f"function: onSaveLocationChange - directory: {directory}")
+            f"function: onSaveLocationChange - directory: {self.user_directory}")
 
     def download_button(self):
         """ When download button is pressed
         """
-        global ytube
-        global directory
 
-        if ytube is not None:
-            self.download(directory)
+        if self.ytube is not None:
+            self.download(location=self.user_directory)
 
     def showPopUp(self, message):
         """ Show pop up message
 
         Args:
-            message: The message to display        
+            message: The message to display
 
         """
         msg = QMessageBox()
@@ -126,7 +123,7 @@ class Ui(QtWidgets.QMainWindow):
         self.progressBar.setValue(
             round((1 - bytes_remaining / file_size) * 100, 3))
 
-    def download(self, location=None, quality=None):
+    def download(self, location=DEFAULT_DIRECTORY, quality=None):
         """ Download the video. Default save location is './downloads'
 
         Args:
@@ -136,18 +133,16 @@ class Ui(QtWidgets.QMainWindow):
         """
         # TODO: support manual directory entry
 
-        global ytube
+        # global ytube
 
         print(f"location: {location}")
         print(f"quality: {quality}")
 
-        if location is None:
-            location = './downloads'
         if quality is None:
-            ytube.streams.first().download(location)
+            self.ytube.download(folder=location)
 
         self.showPopUp(
-            f"{ytube.title} - has been downloaded successfully to:\
+            f"{self.ytube.videoTitle} - has been downloaded successfully to:\
             \n{os.path.abspath(location)}")
 
 

--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -13,7 +13,6 @@ from core import YouTubeVideo
 from helpers import Helpers
 
 
-# ytube = None
 DEFAULT_DIRECTORY = './downloads'
 
 
@@ -51,7 +50,6 @@ class Ui(QtWidgets.QMainWindow):
     def enterURL(self):
         """ When OK button is pressed.
         Use the given URL to retrieve video information and process it
-
         """
 
         link = self.lineEditURL.text()
@@ -97,7 +95,6 @@ class Ui(QtWidgets.QMainWindow):
     def download_button(self):
         """ When download button is pressed
         """
-
         if self.ytube is not None:
             self.download(location=self.user_directory)
 
@@ -119,7 +116,6 @@ class Ui(QtWidgets.QMainWindow):
         """
         print("on process callback")
         file_size = stream.filesize
-        # print(f"{round((1 - bytes_remaining / file_size) * 100, 3)}%")
         self.progressBar.setValue(
             round((1 - bytes_remaining / file_size) * 100, 3))
 
@@ -132,8 +128,6 @@ class Ui(QtWidgets.QMainWindow):
 
         """
         # TODO: support manual directory entry
-
-        # global ytube
 
         print(f"location: {location}")
         print(f"quality: {quality}")

--- a/youtubedl/pyqt.py
+++ b/youtubedl/pyqt.py
@@ -55,7 +55,7 @@ class Ui(QtWidgets.QMainWindow):
         """
 
         link = self.lineEditURL.text()
-        self.ytube = YouTubeVideo(link) #, on_progress_callback=self.download_progress)
+        self.ytube = YouTubeVideo(link, progress_callback=self.download_progress)
 
         # Display video title
         self.labelVideoTitle.setText(self.ytube.videoTitle)
@@ -113,11 +113,11 @@ class Ui(QtWidgets.QMainWindow):
         msg.setText(message)
         x = msg.exec_()
 
-    def download_progress(self, stream, chunk, file_handle, bytes_remaining):
+    def download_progress(self, stream=None, chunk=None, file_handle=None, bytes_remaining=None):
         """
         Updates progress bar on download_progress callback
         """
-        # print("on process callback")
+        print("on process callback")
         file_size = stream.filesize
         # print(f"{round((1 - bytes_remaining / file_size) * 100, 3)}%")
         self.progressBar.setValue(

--- a/youtubedl/tests/tests.py
+++ b/youtubedl/tests/tests.py
@@ -1,0 +1,1 @@
+import unittest


### PR DESCRIPTION
I included a new class, Video, as an interface between the GUI code and the YouTubeVideo class. The reason for this is to isolate the calls from the pytube3 module, so that future modifications to the code are restricted to few places as possible.

Also, using that arrangement, we can create a dispatcher function to create the objects of other streaming services we deem interesting to implement.