### PR TITLE
Update pytube3 dependency to 9.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5==5.14.1
 PyQt5-sip==12.7.0
-pytube3==9.5.11
+pytube3>=9.6.2
 typing-extensions==3.7.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5==5.14.1
 PyQt5-sip==12.7.0
-pytube3>=9.6.2
+pytube3>=9.6.3
 typing-extensions==3.7.4.1


### PR DESCRIPTION
The current version of pytube3 which we are using, `9.5.11`, may be outdated, so I'd suggest moving the version on requirements.txt on to the current version, 9.6.2.