### PR TITLE
bugfix: updated core and gui to new callback method from pytube3 > v …

### DIFF
--- a/youtubedl/core.py
+++ b/youtubedl/core.py
@@ -180,7 +180,7 @@ class YouTubeVideo(Video):
         A list of progressive stream objects consisting of the available stream qualities for the video
 
         """
-        return self.yt.streams.filter(progressive=True).all()
+        return self.yt.streams.filter(progressive=True)
 
     def download(self, location=DEFAULT_DIRECTORY, itag=None):
         """ Download the video. Default save location is './downloads'

--- a/youtubedl/gui.py
+++ b/youtubedl/gui.py
@@ -164,7 +164,7 @@ class Ui(QtWidgets.QMainWindow):
         msg.setText(message)
         msg.exec_()
 
-    def download_progress(self, stream=None, chunk=None, file_handle=None, bytes_remaining=None):
+    def download_progress(self, stream=None, chunk=None, bytes_remaining=None):
         """
         Updates progress bar on download_progress callback
         """


### PR DESCRIPTION
Fixed the issue where if you had a newer version of pytube3 (9.6.3+) it would break the download and make the app crash.

Haven't tested with a previous pytube version, so I might want to check that later on, as this is a quick and dirty bugfix

Steps to test:
- pip install pytube==9.6.4
- open application
- download file